### PR TITLE
Fix logo "String" type warnings

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -16,7 +16,7 @@
                 alternative
                 is-nav-bar
                 has-custom-height
-                custom-height="65"
+                :custom-height="65"
               />
             </NuxtLink>
           </v-toolbar-title>
@@ -74,7 +74,7 @@
                 alternative
                 is-nav-bar
                 has-custom-height
-                custom-height="50"
+                :custom-height="50"
               />
             </v-list-item-title>
           </v-list-item>

--- a/pages/comissao.vue
+++ b/pages/comissao.vue
@@ -94,7 +94,7 @@ export default {
   },
   computed: {
     logoHeight() {
-      return this.$vuetify.breakpoint.mdAndDown ? '300px' : '400px'
+      return this.$vuetify.breakpoint.mdAndDown ? 300 : 400
     },
   },
 }


### PR DESCRIPTION
## Changes

- Add ":" to logo `custom-height` property and fix String type instead of Number type from values of this property