### PR TITLE
Fix deprecated lazy prop from v-tooltip

### DIFF
--- a/pages/comissao.vue
+++ b/pages/comissao.vue
@@ -12,7 +12,7 @@
             />
           </v-card-title>
           <v-card-text>
-            <v-tooltip bottom lazy>
+            <v-tooltip bottom>
               <template #activator="{ on }">
                 <h2 class="titulo txtWhite" v-on="on">O que é a Comissão?</h2>
               </template>


### PR DESCRIPTION
## Changes

- Remove "lazy prop" from `v-tooltip` component