### PR TITLE
Fix rounded property type of v-btn

### DIFF
--- a/components/Button.vue
+++ b/components/Button.vue
@@ -1,7 +1,7 @@
 <template>
   <v-btn
     class="padraoButton"
-    rounded="pill"
+    rounded
     elevation="0"
     large
     :dark="dark"


### PR DESCRIPTION
## Changes

- Update `rounded` component type from "String" to Boolean type to avoid warnings.

**NOTE**: The "String" type is only supported on Vuetify 3, but we are using Vuetify 2.