### PR TITLE
Close reception week timeline

### DIFF
--- a/pages/semana.vue
+++ b/pages/semana.vue
@@ -56,7 +56,7 @@
       <template #right>
         <div class="py-md-10 pt-5 text-center text-md-left">
           <h2 class="titulo white--text">Cronograma</h2>
-          <EventosTabela mostrar-cronograma />
+          <EventosTabela />
         </div>
       </template>
     </PageBar>


### PR DESCRIPTION
## Changes

- Remove `mostrar-cronograma` from `EventosTabela` component to don't show the timeline